### PR TITLE
fix incorrect npm scope

### DIFF
--- a/packages/carta-md/readME.md
+++ b/packages/carta-md/readME.md
@@ -33,7 +33,7 @@ npm i carta-md
 Plugins:
 
 ```
-npm i @carta/plugin-name
+npm i @cartamd/plugin-name
 ```
 
 ### Basic configuration


### PR DESCRIPTION
I tried installing a plugin and it failed, turns out the README doesn't use the correct npm scope.

Also, out of curiosity, why is it called readME and not README?