### PR TITLE
fix textarea selector specificity

### DIFF
--- a/packages/carta-md/src/lib/internal/components/MarkdownInput.svelte
+++ b/packages/carta-md/src/lib/internal/components/MarkdownInput.svelte
@@ -35,23 +35,30 @@
 </script>
 
 <div on:click={focus} on:keydown={focus} class="carta-input">
-	<pre class="hljs carta-font-code" aria-hidden="true">{@html highlighted}</pre>
+	<div class="carta-input-wrapper">
+		<pre class="hljs carta-font-code" aria-hidden="true">{@html highlighted}</pre>
 
-	<textarea
-		name="md"
-		id="md"
-		bind:value
-		bind:this={textarea}
-		on:input={resize}
-		spellcheck="false"
-		class="carta-font-code"
-	/>
+		<textarea
+			name="md"
+			id="md"
+			bind:value
+			bind:this={textarea}
+			on:input={resize}
+			spellcheck="false"
+			class="carta-font-code"
+		/>
+	</div>
 
 	<slot />
 </div>
 
 <style>
-	div {
+	.carta-input {
+		position: relative;
+	}
+
+	.carta-input-wrapper {
+		height: 100%;
 		position: relative;
 		font-family: monospace;
 	}

--- a/packages/carta-md/src/lib/internal/components/MarkdownInput.svelte
+++ b/packages/carta-md/src/lib/internal/components/MarkdownInput.svelte
@@ -53,11 +53,13 @@
 <style>
 	div {
 		position: relative;
+		font-family: monospace;
 	}
 
-	textarea {
+	textarea#md {
 		position: relative;
 		width: 100%;
+		max-width: 100%;
 		min-height: 100%;
 
 		overflow-y: hidden;

--- a/packages/carta-md/src/lib/internal/input.ts
+++ b/packages/carta-md/src/lib/internal/input.ts
@@ -334,16 +334,40 @@ export class CartaInput {
 		if (this.textarea.tagName === 'TEXTAREA') div.style.height = 'auto';
 		if (this.textarea.tagName === 'INPUT') div.style.width = 'auto';
 
+		// Create an element to measure cursor size
 		const span = document.createElement('span');
+		span.className += 'carta-font-code';
 		span.textContent = inputValue.substr(selectionPoint) || '.';
 		div.appendChild(span);
 		document.body.appendChild(div);
 		const { offsetLeft: spanX, offsetTop: spanY } = span;
 		document.body.removeChild(div);
 
+		// Add carta-input padding
+		const cartaInput = document.querySelector('.carta-input');
+		let padding = {
+			top: 0,
+			bottom: 0,
+			left: 0,
+			right: 0
+		};
+		if (cartaInput) {
+			padding = {
+				top: parseInt(getComputedStyle(cartaInput).paddingTop, 10),
+				bottom: parseInt(getComputedStyle(cartaInput).paddingBottom, 10),
+				left: parseInt(getComputedStyle(cartaInput).paddingLeft, 10),
+				right: parseInt(getComputedStyle(cartaInput).paddingRight, 10)
+			};
+		}
+
 		return {
-			x: inputX + spanX,
-			y: inputY + spanY
+			x: inputX + spanX + padding.left,
+			y: inputY + spanY + padding.right,
+
+			left: inputX + spanX + padding.left,
+			top: inputY + spanY + padding.top,
+			right: this.textarea.clientWidth - inputX + padding.right,
+			bottom: this.textarea.clientHeight - inputY + padding.right
 		};
 	}
 }

--- a/packages/plugin-emoji/src/lib/Emoji.svelte
+++ b/packages/plugin-emoji/src/lib/Emoji.svelte
@@ -12,7 +12,7 @@
 	export let outTransition: (node: Element) => TransitionConfig;
 
 	let visible = false;
-	let caretPosition = { x: 0, y: 0 };
+	let caretPosition = { left: 0, right: 0, top: 0, bottom: 0 };
 	let elemWidth: number, elemHeight: number;
 	let style = '';
 	let filter = '';
@@ -101,7 +101,7 @@
 	function getComponentStyle() {
 		if (!carta.input) return ``;
 		// Left/Right
-		let left: number | undefined = caretPosition.x;
+		let left: number | undefined = caretPosition.left;
 		let right: number | undefined;
 
 		if (left + elemWidth >= carta.input.textarea.clientWidth) {
@@ -109,7 +109,7 @@
 			left = undefined;
 		}
 		// Top/Bottom
-		let top: number | undefined = caretPosition.y;
+		let top: number | undefined = caretPosition.top;
 		let bottom: number | undefined;
 
 		if (top + elemHeight >= carta.input.textarea.clientHeight) {
@@ -118,11 +118,11 @@
 		}
 
 		return `
-			--left: ${left ? left + 'px' : 'unset'};
-			--right: ${right ? right + 'px' : 'unset'};
-			--top: ${top ? top + 'px' : 'unset'};
-			--bottom: ${bottom ? bottom + 'px' : 'unset'};
-			--margin: ${window.getComputedStyle(carta.input.textarea).fontSize};
+			--left: ${left !== undefined ? left + 'px' : 'unset'};
+			--right: ${right !== undefined ? right + 'px' : 'unset'};
+			--top: ${top !== undefined ? top + 'px' : 'unset'};
+			--bottom: ${bottom !== undefined ? bottom + 'px' : 'unset'};
+			--font-size: ${window.getComputedStyle(carta.input.textarea).fontSize}
       --cols: ${cols};
 		`;
 	}
@@ -185,8 +185,8 @@
 		position: absolute;
 		left: var(--left);
 		right: var(--right);
-		top: calc(var(--top) + var(--margin) + 4px);
-		bottom: calc(var(--bottom) + var(--margin) * 2 + 4px);
+		top: calc(var(--top) + var(--font-size) + 4px);
+		bottom: calc(var(--bottom) + var(--font-size) * 2 + 4px);
 
 		display: grid;
 		grid-template-columns: repeat(var(--cols), 1fr);

--- a/packages/plugin-slash/src/lib/Slash.svelte
+++ b/packages/plugin-slash/src/lib/Slash.svelte
@@ -10,7 +10,7 @@
 	export let outTransition: (node: Element) => TransitionConfig;
 
 	let visible = false;
-	let caretPosition = { x: 0, y: 0 };
+	let caretPosition = { left: 0, right: 0, top: 0, bottom: 0 };
 	let hoveringIndex = 0;
 	let filter = '';
 	let slashPosition = 0;
@@ -95,7 +95,7 @@
 	function getComponentStyle() {
 		if (!carta.input) return ``;
 		// Left/Right
-		let left: number | undefined = caretPosition.x;
+		let left: number | undefined = caretPosition.left;
 		let right: number | undefined;
 
 		if (left + elemWidth >= carta.input.textarea.clientWidth) {
@@ -103,7 +103,7 @@
 			left = undefined;
 		}
 		// Top/Bottom
-		let top: number | undefined = caretPosition.y;
+		let top: number | undefined = caretPosition.top;
 		let bottom: number | undefined;
 
 		if (top + elemHeight >= carta.input.textarea.clientHeight) {
@@ -112,11 +112,11 @@
 		}
 
 		return `
-			--left: ${left ? left + 'px' : 'unset'};
-			--right: ${right ? right + 'px' : 'unset'};
-			--top: ${top ? top + 'px' : 'unset'};
-			--bottom: ${bottom ? bottom + 'px' : 'unset'};
-			--margin: ${window.getComputedStyle(carta.input.textarea).fontSize}
+			--left: ${left !== undefined ? left + 'px' : 'unset'};
+			--right: ${right !== undefined ? right + 'px' : 'unset'};
+			--top: ${top !== undefined ? top + 'px' : 'unset'};
+			--bottom: ${bottom !== undefined ? bottom + 'px' : 'unset'};
+			--font-size: ${window.getComputedStyle(carta.input.textarea).fontSize}
 		`;
 	}
 
@@ -212,8 +212,8 @@
 		position: absolute;
 		left: var(--left);
 		right: var(--right);
-		top: calc(var(--top) + var(--margin) + 4px);
-		bottom: calc(var(--bottom) + var(--margin) * 2 + 4px);
+		top: calc(var(--top) + var(--font-size) + 4px);
+		bottom: calc(var(--bottom) + var(--font-size) * 2 + 4px);
 	}
 
 	.carta-slash span {


### PR DESCRIPTION
closes #2

1. The increased specificity should stop accidental overrides while allowing someone who actually wants to override the ability to do so.
2.  `max-width` is now set so a global `textarea` selector can't mess that up anymore.
3. Is a bit of specific fallback, it only applies when someone has a `textarea` with `font-family: inherit` and doesn't have their font family set in `.carta-font-code`. But it's a simple thing to add and it happened to me, so I guess it can happen to others? If this doesn't get merged, maybe mention setting `.carta-font-code` somewhere else in the README? It's easy to glance over, but can lead to the editor being very wonky if not set.