### PR TITLE
Sanitizer should run on raw markdown not marked output

### DIFF
--- a/packages/carta-md/src/lib/internal/carta.ts
+++ b/packages/carta-md/src/lib/internal/carta.ts
@@ -153,8 +153,8 @@ export class Carta {
 	 * @returns Rendered html.
 	 */
 	public async render(markdown: string): Promise<string> {
-		const dirty = await marked.parse(markdown, { async: true });
-		return (this.options?.sanitizer && this.options?.sanitizer(dirty)) ?? dirty;
+		markdown = this.options?.sanitizer ? this.options?.sanitizer(markdown) : markdown;
+		return await marked.parse(markdown, { async: true });
 	}
 
 	/**


### PR DESCRIPTION
closes #6 
I wanted to get your input on how you want to tackle this so I didn't go beyond the simplest scope.
Should there be a second, separate sanitization option that runs on the parsed output?
Also knowing how people are probably  going to forget about sanitization sometimes, should it be mandatory? With having to specify `false` or `(input) => input` or something?